### PR TITLE
Fix wrong link in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ This repository contains various 3D printed components required to assemble the 
 
 ### Holders (Recommended to Print in PETG Filament)
 - [Clamp Holder](https://github.com/Sorakage033/SlimeVR-CheeseCake/blob/main/004-3D%20Print%20Model/004-''CLAMP''Holder.stl) - Fits 4cm and 3cm straps.
-- [Clamp Holder 5cm Strap](https://github.com/Sorakage033/SlimeVR-CheeseCake/blob/main/004-3D%20Print%20Model/004-2-''CLAMP''Holder.stl) - Fits 5cm straps.
+- [Clamp Holder 5cm Strap](https://github.com/Sorakage033/SlimeVR-CheeseCake/blob/main/004-3D%20Print%20Model/004-2-''CLAMP''Holder-5cm.stl) - Fits 5cm straps.
 - [GoPro Chest Harness Compatible Clamp Holder](https://github.com/Sorakage033/SlimeVR-CheeseCake/blob/main/004-3D%20Print%20Model/004-1-''CLAMP''GoPro_Holder.stl) - For GoPro chest harness compatibility.
 - [Slide Holder](https://github.com/Sorakage033/SlimeVR-CheeseCake/blob/main/004-3D%20Print%20Model/005-''SLIDE''Holder.stl) - Fits 4cm and 3cm straps.
-- [Slide Holder 5cm Strap](https://github.com/Sorakage033/SlimeVR-CheeseCake/blob/main/004-3D%20Print%20Model/005-1-''SLIDE''Holder.stl) - Fits 5cm straps.
+- [Slide Holder 5cm Strap](https://github.com/Sorakage033/SlimeVR-CheeseCake/blob/main/004-3D%20Print%20Model/005-1-''SLIDE''Holder-5cm.stl) - Fits 5cm straps.
 
 ### Charging Dock (Recommended to Build the Type-C ChargeDock)
 - **8-Tracker Type-C ChargeDock**     


### PR DESCRIPTION
The links to `Clamp Holder 5cm Strap` and `Slide Holder 5cm Strap` in the Holders section were in nonexistent files, so the links have been fixed.